### PR TITLE
Fix misalignment between channel A and channel B

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Essentially, the visible channel gets too bright. When making an HRPT composite,
 
 
 # How to run it
-There are two seperate scripts - channelseperate seperates channels from a raw APT image, and makergb uses the channels to create the final composite (output image is in color.png).
+There are two seperate scripts - channelcropper seperates channels from a raw APT image, and makeRGB uses the channels to create the final composite (output image is in color.png).
 ```
-python channelseperate.py input.png cha.png chb.png
-python makergb.py -ir (do ir blend) -boost (boost the land color on very blue images) cha.png chb.png
+python channelcropper.py input.png cha.png chb.png
+python makeRGB.py -ir (do ir blend) -boost (boost the land color on very blue images) cha.png chb.png
 ```
 
 # Image Gallery

--- a/channelcropper.py
+++ b/channelcropper.py
@@ -12,17 +12,29 @@ iar = i.load()
 xsize,ysize = i.size
 cha = Image.new('RGB',(APT_CH_WIDTH,ysize))
 chb = Image.new('RGB',(APT_CH_WIDTH,ysize))
-(left, upper, right, lower) = (APT_SYNC_WIDTH+APT_SPC_WIDTH, 1,APT_SYNC_WIDTH+APT_SPC_WIDTH+APT_CH_WIDTH-10,ysize)
+
+(left, upper, right, lower) = (
+        APT_SYNC_WIDTH + APT_SPC_WIDTH,
+        1,
+        APT_SYNC_WIDTH + APT_SPC_WIDTH + APT_CH_WIDTH - 10,
+        ysize
+    )
 cha = i.crop((left, upper, right, lower))
+
 #cha.show()
-(left, upper, right, lower) = (APT_SYNC_WIDTH+APT_SPC_WIDTH+APT_CH_WIDTH+APT_SYNC_WIDTH+APT_SPC_WIDTH+APT_TELE_WIDTH, 1,APT_SYNC_WIDTH+APT_SPC_WIDTH+APT_CH_WIDTH+APT_SYNC_WIDTH+APT_SPC_WIDTH+APT_CH_WIDTH+10,ysize)
+(left, upper, right, lower) = (
+        APT_SYNC_WIDTH + APT_SPC_WIDTH + APT_CH_WIDTH + APT_SYNC_WIDTH + APT_SPC_WIDTH + APT_TELE_WIDTH,
+        1,
+        APT_SYNC_WIDTH + APT_SPC_WIDTH + APT_CH_WIDTH + APT_SYNC_WIDTH + APT_SPC_WIDTH + APT_TELE_WIDTH + APT_CH_WIDTH - 10,
+        ysize
+    )
 
 chb = i.crop((left, upper, right, lower))
 
 #chb.show()
 
-cha = cha.resize((909,ysize), Image.ANTIALIAS)
-chb = chb.resize((909,ysize), Image.ANTIALIAS)
+cha = cha.resize((APT_CH_WIDTH,ysize), Image.ANTIALIAS)
+chb = chb.resize((APT_CH_WIDTH,ysize), Image.ANTIALIAS)
 
 cha.save(sys.argv[2])
 chb.save(sys.argv[3])


### PR DESCRIPTION
Fixed that channel A and channel B were cropped with different widths and were later misaligned when resized. See example below. Also I changed the script names in the README

Before:
![before](https://user-images.githubusercontent.com/6921727/194708357-7c9f5b80-74f5-4ee9-9cf6-cb0d7bf754b4.png)

After:
![after](https://user-images.githubusercontent.com/6921727/194708325-5f48fdd7-30a2-4f61-aea5-4c07a8692d27.png)

